### PR TITLE
Handle keypad sequence reset and fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ A calm, keypad-first trainer for multiplication tables:
 ```bash
 python3 -m pip install -r requirements.txt
 python3 -m streamlit run times_tables_streamlit.py
+```

--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -282,8 +282,16 @@ def _handle_keypad_payload(payload):
         code = text
 
     last = st.session_state.get("last_kp_seq", -1)
-    if (seq is None) or (last < 0) or (seq > last):
-        st.session_state.last_kp_seq = (last + 1) if (seq is None) else seq
+
+    # Only ignore duplicates with the same sequence number. If the custom
+    # component reloads it will restart the sequence at 0 which previously
+    # caused all subsequent key presses to be ignored. Accept the event whenever
+    # the sequence changes or no sequence was provided.
+    if seq is None:
+        st.session_state.last_kp_seq = last + 1
+        _kp_apply(code)
+    elif seq != last:
+        st.session_state.last_kp_seq = seq
         _kp_apply(code)
 
 def _timers_row(now_ts: float):


### PR DESCRIPTION
## Summary
- handle keypad component sequence numbers resetting so keypad continues working after reload
- close README's run instructions code block

## Testing
- `python -m py_compile times_tables_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898aa49a2288326b65877703ff215ab