### PR TITLE
feat: add adaptive per-question timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A calm, keypad-first trainer for multiplication tables:
 - On-screen keypad; auto-submit when the answer reaches the right number of digits.
 - Clear visual feedback (red solid on wrong; green dashed on correct).
 - Spaced repetition: a missed item reappears after 2–4 other questions; if wrong twice, it won’t reappear this session and is highlighted in the report.
+- Adaptive timing: per-question limit adjusts ±10% based on answer speed and accuracy (2–30 s, saved between sessions).
 
 ## Run locally
 ```bash


### PR DESCRIPTION
## Summary
- allow fractional per-question time in settings
- adjust per-question baseline up or down 10% based on speed/correctness, capped 2–30s
- persist updated baseline to `tt.settings.v1` local storage at session end and surface current baseline during practice

## Testing
- `python -m py_compile times_tables_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898bc2f5180832683b0389714d85f69