### PR TITLE
Streamline mobile Practice screen layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ python3 -m streamlit run times_tables_streamlit.py
 
 ## Mobile layout
 
-The app uses dynamic viewport units (`100dvh` with a `100vh` fallback) and clamps the keypad area to `height: clamp(260px, 38dvh, 340px)` to keep all four rows visible on phones like the Pixel 7a/9a.
+The app keeps four keypad rows visible on phones like the Pixel 7a/9a by removing non‑essential chrome, shrinking the timers, using dynamic viewport units (`100dvh` with a `100vh` fallback), and clamping the keypad pane to `height: clamp(248px, 40dvh, 320px)`.


### PR DESCRIPTION
## Summary
- Compact the Practice timers into a single 40px header row and drop the Stop button
- Remove extra chrome and captions for a no-scroll mobile screen
- Use dynamic viewport units and clamp keypad height for four-row visibility

## Testing
- `python -m py_compile times_tables_streamlit.py`

## Screenshots
- TODO: add Pixel 7a/9a safe mode on/off screenshots

------
https://chatgpt.com/codex/tasks/task_e_6898ceed7b9083269d0e7b0dee08f861