### PR TITLE
Fix localStorage persistence and add storage debug panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ python3 -m streamlit run times_tables_streamlit.py
 ## Mobile layout
 
 The app keeps four keypad rows visible on phones like the Pixel 7a/9a by removing non‑essential chrome, shrinking the timers, using dynamic viewport units (`100dvh` with a `100vh` fallback), and clamping the keypad pane to `height: clamp(248px, 40dvh, 320px)`.
+
+## Local data & TTL
+
+The app stores your settings in the browser's `localStorage` under `tt.settings.v1`. Each change or start refreshes a 30‑day expiry. Data is scoped per device/browser and, in development, per port. If Streamlit restarts on a new port, previous settings won't be found (normal). To inspect or clear data, open the **Settings** screen, enable **Debug storage**, and use the provided buttons.

--- a/ls_component/index.html
+++ b/ls_component/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>LS</title>
+</head>
+<body>
+<script>
+const send = (v)=>{
+  if (window.Streamlit && window.Streamlit.setComponentValue){
+    window.Streamlit.setComponentValue(v);
+  } else {
+    window.parent.postMessage({isStreamlitMessage:true, type:"streamlit:setComponentValue", value:v, apiVersion:1}, "*");
+  }
+};
+const ready = ()=>{
+  if (window.Streamlit && window.Streamlit.setComponentReady){
+    window.Streamlit.setComponentReady();
+  } else {
+    window.parent.postMessage({isStreamlitMessage:true, type:"streamlit:componentReady", apiVersion:1}, "*");
+  }
+  if (window.Streamlit && window.Streamlit.setFrameHeight){
+    window.Streamlit.setFrameHeight(0);
+  } else {
+    window.parent.postMessage({isStreamlitMessage:true, type:"streamlit:setFrameHeight", height:0, apiVersion:1}, "*");
+  }
+};
+window.addEventListener("message", (e)=>{
+  const d = e.data || {};
+  if (d.type === "streamlit:render"){
+    const args = d.args || {};
+    const action = args.action;
+    const key = args.key;
+    let result = null;
+    try{
+      if (action === "get"){
+        const raw = localStorage.getItem(key);
+        if (!raw){
+          result = null;
+        } else {
+          const obj = JSON.parse(raw);
+          if (obj && obj.expires_at && Date.parse(obj.expires_at) < Date.now()){
+            localStorage.removeItem(key);
+            result = null;
+          } else {
+            result = obj;
+          }
+        }
+      } else if (action === "set"){
+        let val = args.value || {};
+        if (args.ttl_days){
+          val.expires_at = new Date(Date.now() + args.ttl_days*86400000).toISOString();
+        }
+        localStorage.setItem(key, JSON.stringify(val));
+        result = true;
+      } else if (action === "remove"){
+        localStorage.removeItem(key);
+        result = true;
+      } else if (action === "info"){
+        let ls_ok = true, ls_error = null;
+        try{
+          localStorage.setItem("__tt_probe","1");
+          localStorage.removeItem("__tt_probe");
+        }catch(err){ ls_ok = false; ls_error = err.message; }
+        let stored = null;
+        try{
+          const raw = localStorage.getItem(key);
+          stored = raw ? JSON.parse(raw) : null;
+        }catch(err){}
+        result = {
+          origin: window.location.origin,
+          port: window.location.port || "",
+          now: new Date().toISOString(),
+          ls_ok: ls_ok,
+          ls_error: ls_error,
+          stored: stored
+        };
+      }
+    }catch(err){
+      result = {error: err.message};
+    }
+    send(result);
+  }
+});
+ready();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add localStorage component with TTL enforcement
- load settings on boot and persist them on change/start
- expose optional storage debug panel and document 30-day local data expiry

## Testing
- `python -m py_compile times_tables_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d914742c832687983e4a7366a21b