### PR TITLE
Handle invalid localStorage data

### DIFF
--- a/ls_component/index.html
+++ b/ls_component/index.html
@@ -38,17 +38,22 @@ window.addEventListener("message", (e)=>{
         if (!raw){
           result = null;
         } else {
-          const obj = JSON.parse(raw);
-          if (obj && obj.expires_at && Date.parse(obj.expires_at) < Date.now()){
+          try{
+            const obj = JSON.parse(raw);
+            if (obj && obj.expires_at && Date.parse(obj.expires_at) < Date.now()){
+              localStorage.removeItem(key);
+              result = null;
+            } else {
+              result = obj;
+            }
+          }catch(err){
             localStorage.removeItem(key);
             result = null;
-          } else {
-            result = obj;
           }
         }
       } else if (action === "set"){
-        let val = args.value || {};
-        if (args.ttl_days){
+        let val = (args.value && typeof args.value === "object") ? {...args.value} : {};
+        if (args.ttl_days && typeof val === "object"){
           val.expires_at = new Date(Date.now() + args.ttl_days*86400000).toISOString();
         }
         localStorage.setItem(key, JSON.stringify(val));

--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -46,7 +46,12 @@ def _ls_store():
 
 def ls_get(key):
     if LS_COMPONENT_AVAILABLE:
-        return ls_component(action="get", key=key, default=None)
+        res = ls_component(action="get", key=key, default=None)
+        if isinstance(res, dict):
+            if res.get("error") or res.get("ERROR"):
+                ls_remove(key)
+                return None
+        return res
     return _ls_store().get(key)
 
 


### PR DESCRIPTION
## Summary
- guard localStorage reads/writes to avoid corrupt data and remove invalid entries
- ignore component errors when loading settings

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898dc75ce948326a9823ac0af630164