### PR TITLE
Prevent duplicate Streamlit component keys for localStorage operations

### DIFF
--- a/ls_component/index.html
+++ b/ls_component/index.html
@@ -30,24 +30,24 @@ window.addEventListener("message", (e)=>{
   if (d.type === "streamlit:render"){
     const args = d.args || {};
     const action = args.action;
-    const key = args.key;
+    const ls_key = args.ls_key !== undefined ? args.ls_key : args.key;
     let result = null;
     try{
       if (action === "get"){
-        const raw = localStorage.getItem(key);
+        const raw = localStorage.getItem(ls_key);
         if (!raw){
           result = null;
         } else {
           try{
             const obj = JSON.parse(raw);
             if (obj && obj.expires_at && Date.parse(obj.expires_at) < Date.now()){
-              localStorage.removeItem(key);
+              localStorage.removeItem(ls_key);
               result = null;
             } else {
               result = obj;
             }
           }catch(err){
-            localStorage.removeItem(key);
+            localStorage.removeItem(ls_key);
             result = null;
           }
         }
@@ -56,10 +56,10 @@ window.addEventListener("message", (e)=>{
         if (args.ttl_days && typeof val === "object"){
           val.expires_at = new Date(Date.now() + args.ttl_days*86400000).toISOString();
         }
-        localStorage.setItem(key, JSON.stringify(val));
+        localStorage.setItem(ls_key, JSON.stringify(val));
         result = true;
       } else if (action === "remove"){
-        localStorage.removeItem(key);
+        localStorage.removeItem(ls_key);
         result = true;
       } else if (action === "info"){
         let ls_ok = true, ls_error = null;
@@ -69,7 +69,7 @@ window.addEventListener("message", (e)=>{
         }catch(err){ ls_ok = false; ls_error = err.message; }
         let stored = null;
         try{
-          const raw = localStorage.getItem(key);
+          const raw = localStorage.getItem(ls_key);
           stored = raw ? JSON.parse(raw) : null;
         }catch(err){}
         result = {

--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -44,9 +44,18 @@ def _ls_store():
     return st.session_state._ls
 
 
+_ls_component_counter = 0
+
+
+def _ls_component_key():
+    global _ls_component_counter
+    _ls_component_counter += 1
+    return f"ls_{_ls_component_counter}"
+
+
 def ls_get(key):
     if LS_COMPONENT_AVAILABLE:
-        res = ls_component(action="get", key=key, default=None)
+        res = ls_component(action="get", ls_key=key, key=_ls_component_key(), default=None)
         if isinstance(res, dict):
             if res.get("error") or res.get("ERROR"):
                 ls_remove(key)
@@ -57,14 +66,14 @@ def ls_get(key):
 
 def ls_set(key, value, ttl_days=30):
     if LS_COMPONENT_AVAILABLE:
-        return ls_component(action="set", key=key, value=value, ttl_days=ttl_days, default=None)
+        return ls_component(action="set", ls_key=key, value=value, ttl_days=ttl_days, key=_ls_component_key(), default=None)
     _ls_store()[key] = value
     return True
 
 
 def ls_remove(key):
     if LS_COMPONENT_AVAILABLE:
-        return ls_component(action="remove", key=key, default=None)
+        return ls_component(action="remove", ls_key=key, key=_ls_component_key(), default=None)
     _ls_store().pop(key, None)
     return True
 
@@ -131,7 +140,7 @@ def _update_session_duration():
 
 
 def render_debug_panel():
-    info = ls_component(action="info", key="tt.settings.v1", default={}) if LS_COMPONENT_AVAILABLE else {}
+    info = ls_component(action="info", ls_key="tt.settings.v1", key=_ls_component_key(), default={}) if LS_COMPONENT_AVAILABLE else {}
     st.write("#### Storage debug")
     if info.get("origin"):
         st.text(f"Origin: {info.get('origin')}")


### PR DESCRIPTION
## Summary
- ensure ls_component uses separate `ls_key` argument so Streamlit element keys can remain unique
- generate unique keys for each localStorage interaction to avoid StreamlitDuplicateElementKey errors

## Testing
- `python -m py_compile times_tables_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898de0536488326ba8cade91d3a7fa8