### PR TITLE
Ensure single keypad in practice screen

### DIFF
--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -562,15 +562,23 @@ def screen_practice():
 
     # Keep visual order: prompt above keypad; but render keypad first to read payload this run.
     top_area = st.container()
-    keypad_area = st.container()
+
+    # Reuse a stable container for the keypad and clear it each run so old
+    # fallback keypads do not linger if the custom component loads later.
+    if "_keypad_area" not in st.session_state:
+        st.session_state._keypad_area = st.container()
+    keypad_area = st.session_state._keypad_area
+    keypad_area.empty()
 
     # --- Keypad (render first) ---
     with keypad_area:
+        payload = None
         if KP_COMPONENT_AVAILABLE:
             payload = keypad(default=None)  # "CODE|SEQ" or None
+            st.caption("Keypad: custom")
         else:
-            payload = None
             render_fallback_keypad()
+            st.caption("Keypad: fallback")
 
     # Process keypad event (first-press fix)
     _handle_keypad_payload(payload)


### PR DESCRIPTION
## Summary
- Clear and reuse keypad container before rendering to prevent lingering fallback keypads
- Render fallback keypad only when the custom component is unavailable, and add caption showing which keypad is active

## Testing
- `python -m py_compile times_tables_streamlit.py`
- `streamlit run times_tables_streamlit.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_6898e2cb38708326beddaea25ff46fff