### PR TITLE
Fix practice screen disappearing

### DIFF
--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -616,12 +616,12 @@ def screen_practice():
     # Reuse a stable container for the keypad and clear it each run so old
     # fallback keypads do not linger if the custom component loads later.
     if "_keypad_area" not in st.session_state:
-        st.session_state._keypad_area = st.container()
+        st.session_state._keypad_area = st.empty()
     keypad_area = st.session_state._keypad_area
-    keypad_area.empty()
+    keypad_area = keypad_area.empty()
 
     # --- Keypad (render first) ---
-    with keypad_area:
+    with keypad_area.container():
         payload = None
         if KP_COMPONENT_AVAILABLE:
             payload = keypad(default=None)  # "CODE|SEQ" or None


### PR DESCRIPTION
## Summary
- Use a placeholder container for the keypad area so it re-renders correctly on each run

## Testing
- `python -m py_compile times_tables_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898eb6d38448326a182ce25ebcc8d1f