### PR TITLE
Retry loading settings from storage on boot

### DIFF
--- a/times_tables_streamlit.py
+++ b/times_tables_streamlit.py
@@ -161,6 +161,7 @@ def persist_settings():
 
 def load_settings_on_boot():
     ss = st.session_state
+    ss.boot_load_attempts = ss.get("boot_load_attempts", 0) + 1
     obj = ls_get("tt.settings.v1")
     if isinstance(obj, dict):
         if isinstance(obj.get("user"), str):
@@ -175,7 +176,10 @@ def load_settings_on_boot():
             ss.total_seconds = max(0, int(obj["session_secs"]))
     ss.session_mins = ss.total_seconds // 60
     ss.session_secs = ss.total_seconds % 60
-    ss.did_boot_load = True
+    if isinstance(obj, dict) or ss.boot_load_attempts >= 2:
+        ss.did_boot_load = True
+    else:
+        ss.needs_rerun = True
 
 
 def _update_session_duration():
@@ -265,6 +269,7 @@ def _init_state():
     ss.setdefault("session_mins", ss.total_seconds // 60)
     ss.setdefault("session_secs", ss.total_seconds % 60)
     ss.setdefault("did_boot_load", False)
+    ss.setdefault("boot_load_attempts", 0)
 
     # Timers
     ss.setdefault("session_start", 0.0)


### PR DESCRIPTION
## Summary
- track boot load attempts in session state
- retry loading localStorage settings before showing defaults

## Testing
- `python -m py_compile times_tables_streamlit.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f6905dec8326a4680bba9558b9dd